### PR TITLE
init: use different buffer for c(hange)

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -316,7 +316,9 @@ nmap <S-Tab> :bprevious<CR>
 noremap <leader>e :PlugInstall<CR>
 noremap <C-q> :q<CR>
 
-" use a different register for delete and paste
+" use a different register for change, delete and paste
+nnoremap c "_c
+vnoremap c "_c
 nnoremap d "_d
 vnoremap d "_d
 vnoremap p "_dP


### PR DESCRIPTION
Every time c(hange) is used, the part that was cut out gets copied to the clipboard due to your configs using the system clipboard by default. d(elete) doesn't follow this behaviour, creating an inconsistency. I redirected c(hange) to a different buffer, making it usable again.