### PR TITLE
README.md: javascript: Update installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To check if your current environment is correctly set up run `:CheckHealth`.
 ### Environment
 
 - python3: `pip3 install --user pynvim`
-- javascript: `yarn install -g neovim`
+- javascript: `yarn global add neovim`
 
 ### Tools
 


### PR DESCRIPTION
Hello blacksuan19, really enjoying nvim especially with your configs 👍, But I want to tell you that while recently going through the Readme I noticed that:

- "yarn install -g neovim", doesn't work anymore as global flag is depreciated 

 Using "yarn global add neovim" is the correct way to install the package now, I am doing this PR so it would be easy for some other user to go through the README without any problem.