### PR TITLE
fix ultisnips, tmux missing right

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -26,7 +26,6 @@ Plug 'Jorengarenar/vim-MvVis'                           " move visual selection
 Plug 'neoclide/coc.nvim', {'branch': 'release'}         " LSP and more
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }     " fzf itself
 Plug 'junegunn/fzf.vim'                                 " fuzzy search integration
-Plug 'SirVer/ultisnips'                                 " snippets manager
 Plug 'honza/vim-snippets'                               " actual snippets
 Plug 'Yggdroot/indentLine'                              " show indentation lines
 Plug 'tpope/vim-liquid'                                 " liquid language support
@@ -450,6 +449,7 @@ nmap <leader>gb :Gblame<CR>
 
 " tmux navigator
 nnoremap <silent> <C-h> :TmuxNavigateLeft<cr>
+nnoremap <silent> <C-l> :TmuxNavigateRight<cr>
 nnoremap <silent> <C-j> :TmuxNavigateDown<cr>
 nnoremap <silent> <C-k> :TmuxNavigateUp<cr>
 


### PR DESCRIPTION
According to coc-snippet docs ultisnips plugin is not needed, works fine without it in my environment. also ultisnips overrides `<tab>` mappings for some reason (probably there is a flag to fix this somewhere but its not needed anyways).

There was a missing tmux navigation line.