### PR TITLE
python3 host autosearch

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -119,7 +119,11 @@ let g:omni_sql_no_default_maps = 1                      " disable sql omni compl
 let g:loaded_python_provider = 0
 let g:loaded_perl_provider = 0
 let g:loaded_ruby_provider = 0
-let g:python3_host_prog = expand('/usr/bin/python3')
+if glob('~/.python3') != ''
+  let g:python3_host_prog = expand('~/.python3/bin/python')
+else
+  let g:python3_host_prog = systemlist('which python3')[0]
+endif
 
 "" coc
 


### PR DESCRIPTION
This few lines help to search python3 host also on Darwing mac ox.
I try it also on ubuntu focal 20.04 and on neovim 0.51.